### PR TITLE
Implement updating of Terragrunt subdir dependencies via git hash

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -56,6 +56,7 @@ export interface ReleaseResult {
   changelogUrl?: string;
   dependencyUrl?: string;
   deprecationMessage?: string;
+  notes?: string;
   display?: string;
   dockerRegistry?: string;
   dockerRepository?: string;

--- a/lib/datasource/git-subdir-commits/index.spec.ts
+++ b/lib/datasource/git-subdir-commits/index.spec.ts
@@ -1,0 +1,37 @@
+import _simpleGit from 'simple-git';
+import { getPkgReleases } from '..';
+import { id as datasource } from '.';
+
+jest.mock('simple-git');
+const simpleGit: any = _simpleGit;
+
+const depName = 'https://github.com/example/example.git';
+
+describe('datasource/git-refs', () => {
+  describe('getReleases', () => {
+    it('returns nil if response is wrong', async () => {
+      simpleGit.mockReturnValue({
+        listRemote() {
+          return Promise.resolve(null);
+        },
+      });
+      const versions = await getPkgReleases({
+        datasource,
+        depName,
+      });
+      expect(versions).toBeNull();
+    });
+    it('returns nil if remote call throws exception', async () => {
+      simpleGit.mockReturnValue({
+        listRemote() {
+          throw new Error();
+        },
+      });
+      const versions = await getPkgReleases({
+        datasource,
+        depName,
+      });
+      expect(versions).toBeNull();
+    });
+  });
+});

--- a/lib/datasource/git-subdir-commits/index.ts
+++ b/lib/datasource/git-subdir-commits/index.ts
@@ -1,0 +1,88 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import simpleGit from 'simple-git';
+import * as packageCache from '../../util/cache/package';
+import { GetReleasesConfig, Release, ReleaseResult } from '../common';
+
+export const id = 'git-subdir-commits';
+
+const cacheMinutes = 10;
+
+// git will prompt for known hosts or passwords, unless we activate BatchMode
+process.env.GIT_SSH_COMMAND = 'ssh -o BatchMode=yes';
+
+export async function getCommits(
+  { lookupName }: GetReleasesConfig,
+  subdir: string
+): Promise<Release[] | null> {
+  let commits = [];
+
+  const cacheNamespace = 'git-subdir-commits';
+  const cachedResult = await packageCache.get<Release[]>(
+    cacheNamespace,
+    lookupName + subdir
+  );
+  /* istanbul ignore next line */
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  let baseDir;
+  let useCache = false;
+
+  if (
+    process.env.RENOVATE_REPO_CACHE &&
+    fs.existsSync(`${process.env.RENOVATE_REPO_CACHE}/${lookupName}`)
+  ) {
+    useCache = true;
+    baseDir = `${process.env.RENOVATE_REPO_CACHE}/${lookupName}`;
+  } else {
+    baseDir = '/tmp/renovate/' + crypto.randomBytes(20).toString('hex');
+    fs.mkdirSync(baseDir, { recursive: true });
+  }
+
+  try {
+    const git = simpleGit(baseDir);
+    if (!useCache) {
+      await git.clone('git@github.com:' + lookupName, baseDir);
+    }
+    commits = (await git.log({ file: subdir })).all.map((commit) => ({
+      version: commit.hash,
+      gitRef: commit.hash,
+      newDigest: commit.hash,
+      releaseTimestamp: commit.date,
+      changelogUrl: `https://github.com/${lookupName}/commit/${commit.hash}`,
+    }));
+  } finally {
+    if (!useCache) {
+      fs.rmdirSync(baseDir, { recursive: true });
+    }
+  }
+
+  await packageCache.set(
+    cacheNamespace,
+    lookupName + subdir,
+    commits,
+    cacheMinutes
+  );
+
+  return commits;
+}
+
+export async function getReleases({
+  lookupName,
+}: GetReleasesConfig): Promise<ReleaseResult | null> {
+  const [repo, subdir] = lookupName.replace('.git', '').split('//');
+  const commits: Release[] = await getCommits({ lookupName: repo }, subdir);
+
+  const sourceUrl = `https://github.com/${repo}/tree/master/${subdir}`;
+
+  const result: ReleaseResult = {
+    sourceUrl,
+    notes: `[${commits[0].message}](https://github.com/${repo}/commit/${commits[0].version})`,
+    latestVersion: commits[0].version,
+    releases: commits.slice(0, 1),
+  };
+
+  return result;
+}

--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -158,7 +158,7 @@ export function addMetaData(
       let massagedUrl;
       if (parsedUrl.hostname.includes('gitlab')) {
         massagedUrl = massageGitlabUrl(dep.sourceUrl);
-      } else {
+      } else if (!dep.sourceUrl.includes('/tree/')) {
         massagedUrl = massageGithubUrl(dep.sourceUrl);
       }
       // try massaging it

--- a/lib/manager/terragrunt/modules.ts
+++ b/lib/manager/terragrunt/modules.ts
@@ -1,5 +1,5 @@
+import * as datasourceGitSubdirCommits from '../../datasource/git-subdir-commits';
 import * as datasourceGitTags from '../../datasource/git-tags';
-import * as datasourceGithubTags from '../../datasource/github-tags';
 import * as datasourceTerragruntModule from '../../datasource/terraform-module';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
@@ -7,7 +7,7 @@ import { PackageDependency } from '../common';
 import { extractTerragruntProvider } from './providers';
 import { ExtractionResult, TerragruntDependencyTypes } from './util';
 
-const githubRefMatchRegex = /github.com([/:])(?<project>[^/]+\/[a-z0-9-.]+).*\?ref=(?<tag>.*)$/;
+const githubRefMatchRegex = /github.com([/:])(?<project>[^/]+\/[a-z0-9-.]+.*)\?ref=(?<tag>.*)$/;
 const gitTagsRefMatchRegex = /(?:git::)?(?<url>(?:http|https|ssh):\/\/(?:.*@)?(?<path>.*.*\/(?<project>.*\/.*)))\?ref=(?<tag>.*)$/;
 const hostnameMatchRegex = /^(?<hostname>([\w|\d]+\.)+[\w|\d]+)/;
 
@@ -32,10 +32,10 @@ export function analyseTerragruntModule(dep: PackageDependency): void {
   if (githubRefMatch) {
     const depNameShort = githubRefMatch.groups.project.replace(/\.git$/, '');
     dep.depType = 'github';
-    dep.depName = 'github.com/' + depNameShort;
+    dep.depName = depNameShort;
     dep.depNameShort = depNameShort;
     dep.currentValue = githubRefMatch.groups.tag;
-    dep.datasource = datasourceGithubTags.id;
+    dep.datasource = datasourceGitSubdirCommits.id;
     dep.lookupName = depNameShort;
   } else if (gitTagsRefMatch) {
     dep.depType = 'gitTags';

--- a/lib/versioning/githash/index.spec.ts
+++ b/lib/versioning/githash/index.spec.ts
@@ -1,0 +1,24 @@
+import git from '.';
+
+describe('git.', () => {
+  describe('isValid(version)', () => {
+    it('should return true', () => {
+      expect(git.isValid('aabbccdd0011')).toBeTruthy();
+    });
+  });
+  describe('isCompatible(version)', () => {
+    it('should return true', () => {
+      expect(git.isCompatible('')).toBeTruthy();
+    });
+  });
+  describe('isGreaterThan(version1, version2)', () => {
+    it('should return false', () => {
+      expect(git.isGreaterThan('', '')).toBeFalsy();
+    });
+  });
+  describe('valueToVersion(version)', () => {
+    it('should return same as input', () => {
+      expect(git.valueToVersion('')).toEqual('');
+    });
+  });
+});

--- a/lib/versioning/githash/index.ts
+++ b/lib/versioning/githash/index.ts
@@ -1,0 +1,33 @@
+import { VersioningApi } from '../common';
+import * as generic from '../loose/generic';
+
+export const id = 'githash';
+export const displayName = 'githash';
+export const urls = ['https://git-scm.com/'];
+export const supportsRanges = false;
+
+const parse = (version: string): any => ({ release: version });
+
+const isCompatible = (version: string, range: string): boolean => true;
+
+const compare = (version1: string, version2: string): number =>
+  version1 === version2 ? 0 : 1;
+const valueToVersion = (value: string): string => value;
+
+const getMajor = (version: string): string => version;
+const getMinor = (version: string): null => null;
+const getPatch = (version: string): null => null;
+
+export const api: VersioningApi = {
+  ...generic.create({
+    parse,
+    compare,
+  }),
+  isCompatible,
+  valueToVersion,
+  getMajor,
+  getMinor,
+  getPatch,
+};
+
+export default api;

--- a/lib/versioning/githash/readme.md
+++ b/lib/versioning/githash/readme.md
@@ -1,0 +1,1 @@
+Renovate's git versioning is a kind of hack to support git submodule updating.

--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -65,6 +65,7 @@ export interface BranchUpgradeConfig
   changelogUrl?: string;
   dependencyUrl?: string;
   sourceUrl?: string;
+  notes?: string;
 }
 
 export enum PrResult {

--- a/lib/workers/pr/body/index.ts
+++ b/lib/workers/pr/body/index.ts
@@ -7,7 +7,7 @@ import { getPrConfigDescription } from './config-description';
 import { getControls } from './controls';
 import { getPrFooter } from './footer';
 import { getPrHeader } from './header';
-import { getPrExtraNotes, getPrNotes } from './notes';
+import { getPrCommitNotes, getPrExtraNotes, getPrNotes } from './notes';
 import { getPrUpdatesTable } from './updates-table';
 
 function massageUpdateMetadata(config: BranchConfig): void {
@@ -75,7 +75,8 @@ export async function getPrBody(config: BranchConfig): Promise<string> {
   const content = {
     header: getPrHeader(config),
     table: getPrUpdatesTable(config),
-    notes: getPrNotes(config) + getPrExtraNotes(config),
+    notes:
+      getPrNotes(config) + getPrExtraNotes(config) + getPrCommitNotes(config),
     changelogs: getChangelogs(config),
     configDescription: await getPrConfigDescription(config),
     controls: getControls(),

--- a/lib/workers/pr/body/notes.ts
+++ b/lib/workers/pr/body/notes.ts
@@ -46,3 +46,10 @@ export function getPrExtraNotes(config: BranchConfig): string {
 
   return res;
 }
+
+export function getPrCommitNotes(config: BranchConfig): string {
+  if (config.notes) {
+    return `**New pinned commit** (${config.newDigestShort}): ${config.notes}\n\n`;
+  }
+  return '';
+}

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -33,6 +33,7 @@ export interface UpdateResult {
   skipReason: SkipReason;
   releases: Release[];
   fixedVersion?: string;
+  notes?: string;
   updates: LookupUpdate[];
   warnings: ValidationMessage[];
 }
@@ -185,6 +186,8 @@ export async function lookupUpdates(
     res.homepage = dependency.homepage;
     res.changelogUrl = dependency.changelogUrl;
     res.dependencyUrl = dependency?.dependencyUrl;
+    res.notes = dependency.notes;
+
     // TODO: improve this
     // istanbul ignore if
     if (dependency.dockerRegistry) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "renovate",
+  "name": "@emedvedev/renovate",
   "description": "Automated dependency updates. Flexible so you don't need to be.",
-  "version": "0.0.0-semantic-release",
+  "version": "0.0.1",
   "bin": {
     "renovate": "dist/renovate.js",
     "renovate-config-validator": "dist/config-validator.js"
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/renovatebot/renovate.git"
+    "url": "https://github.com/emedvedev/renovate.git"
   },
   "keywords": [
     "automated",


### PR DESCRIPTION
This PR implements:

1. A `git-subdir-commits` datasource: it scans a subdir inside a git repo for updates (via `git log`) and returns the last commit where the subdir was updated.
2. A `githash` versioning schema: it forces an update if the most recent release returned doesn't match the current pinned version.

The combination of the two works the way we want: Renovate will scan `infra-modules` for updates and update the corresponding `infra` and `infra-staging` references. The updates will be per module, not all at once, so we won't get massive 400-module update PRs. Renovate will even group the updates, so if the `explorer` module in `infra-modules` gets a new version, all `explorer` modules inside `infra` will be updated in a single PR.

Generally, this thing works exactly the way we want it to, but the implementation has one unfortunate drawback: if the module is pinned to a _newer_ commit, but that commit didn't bring changes to that specific module, Renovate will still create a PR with an update. It means we can't just pin all module dependencies inside the `infra` repo to the latest `infra-modules` commit every time, but it wouldn't be feasible anyway, because it'd force an Atlantis update of 400 modules at once.

Everything here needs a review from someone with TS knowledge, and also spec and tests still have to be updated.